### PR TITLE
Fix compiler error when bevy change tracking enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/UkoeHB/bevy_cobweb"
 
+[features]
+track_change_detection = ["bevy/track_change_detection"]
+
 [workspace]
 members = ["bevy_cobweb_derive"]
 

--- a/src/react/react_resource.rs
+++ b/src/react/react_resource.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "track_change_detection")]
+use std::panic::Location;
+
 //local shortcuts
 use crate::prelude::*;
 
@@ -101,6 +104,8 @@ impl<'w, R: ReactResource> DetectChanges for ReactRes<'w, R>
     #[inline] fn is_added(&self) -> bool { self.inner.is_added() }
     #[inline] fn is_changed(&self) -> bool { self.inner.is_changed() }
     #[inline] fn last_changed(&self) -> Tick { self.inner.last_changed() }
+    #[cfg(feature = "track_change_detection")]
+    #[inline] fn changed_by(&self) -> &'static Location<'static> { self.inner.changed_by() }
 }
 
 impl<'w, R: ReactResource> Deref for ReactRes<'w, R>
@@ -152,6 +157,8 @@ impl<'w, R: ReactResource> DetectChanges for ReactResMut<'w, R>
     #[inline] fn is_added(&self) -> bool { self.inner.is_added() }
     #[inline] fn is_changed(&self) -> bool { self.inner.is_changed() }
     #[inline] fn last_changed(&self) -> Tick { self.inner.last_changed() }
+    #[cfg(feature = "track_change_detection")]
+    #[inline] fn changed_by(&self) -> &'static Location<'static> { self.inner.changed_by() }
 }
 
 impl<'w, R: ReactResource> Deref for ReactResMut<'w, R>


### PR DESCRIPTION
There's another method that is conditionally added to the `DetectChanges` trait.